### PR TITLE
Fixes the issue with dialog not dismissed by cancellation signal

### DIFF
--- a/library/src/main/java/moe/feng/support/biometricprompt/BiometricPromptApi23Impl.java
+++ b/library/src/main/java/moe/feng/support/biometricprompt/BiometricPromptApi23Impl.java
@@ -97,10 +97,14 @@ class BiometricPromptApi23Impl implements IBiometricPromptImpl {
         }
         this.cancellationSignal = cancel;
         this.callback = callback;
-        if (cancel == null) {
-            cancel = new CancellationSignal();
+        if (cancellationSignal == null) {
+            cancellationSignal = new CancellationSignal();
         }
-        cancel.setOnCancelListener(dialog::cancel);
+        CancellationSignal innerCancel = new CancellationSignal();
+        cancellationSignal.setOnCancelListener(() -> {
+            innerCancel.cancel();
+            dialog.cancel();
+        });
 
         dialog.setOnDismissListener(dialogInterface -> {
             if (cancellationSignal != null && !cancellationSignal.isCanceled()) {
@@ -116,7 +120,7 @@ class BiometricPromptApi23Impl implements IBiometricPromptImpl {
             dialog.getFingerprintIcon().setState(
                     FingerprintIconView.State.ON, false);
             fingerprintManager.authenticate(
-                    toCryptoObjectApi23(crypto), cancellationSignal,
+                    toCryptoObjectApi23(crypto), innerCancel,
                     0, fmAuthCallback, mainHandler);
         });
 
@@ -133,16 +137,20 @@ class BiometricPromptApi23Impl implements IBiometricPromptImpl {
         }
         this.cancellationSignal = cancel;
         this.callback = callback;
-        if (cancel == null) {
-            cancel = new CancellationSignal();
+        if (cancellationSignal == null) {
+            cancellationSignal = new CancellationSignal();
         }
-        cancel.setOnCancelListener(dialog::cancel);
+        CancellationSignal innerCancel = new CancellationSignal();
+        cancellationSignal.setOnCancelListener(() -> {
+            innerCancel.cancel();
+            dialog.cancel();
+        });
 
         dialog.setOnShowListener(d -> {
             dialog.getFingerprintIcon().setState(
                     FingerprintIconView.State.ON, false);
             fingerprintManager.authenticate(
-                    toCryptoObjectApi23(crypto), cancellationSignal,
+                    toCryptoObjectApi23(crypto), innerCancel,
                     0, fmAuthCallback, mainHandler);
         });
 


### PR DESCRIPTION
The cause of the problem is the fact that BiometricPromptApi23Impl for dialog dismiss relies on OnCancelListener listener that is set on cancellationSignal object in "authenticate" and "getAuthenticateDialogForFragment" methods. The same object is passed to the fingerprintManager where the listener gets reset by FinagerpringManager. That's why we have an issue when the dialog is not dismissed after we call cancellationSignal.cancel() from outside of the Prompt.