### PR TITLE
Fixed the negative button is not visible in landscape mode

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/library/src/main/java/moe/feng/support/biometricprompt/FingerprintDialogLayout.java
+++ b/library/src/main/java/moe/feng/support/biometricprompt/FingerprintDialogLayout.java
@@ -8,36 +8,36 @@ import android.util.AttributeSet;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-@RestrictTo({ RestrictTo.Scope.LIBRARY })
+@RestrictTo({RestrictTo.Scope.LIBRARY})
 public class FingerprintDialogLayout extends LinearLayout {
 
-  private FingerprintIconView iconView;
-  private TextView statusView;
+    private FingerprintIconView iconView;
+    private TextView statusView;
 
-  public FingerprintDialogLayout(Context context) {
-    super(context);
-  }
+    public FingerprintDialogLayout(Context context) {
+        super(context);
+    }
 
-  public FingerprintDialogLayout(Context context, @Nullable AttributeSet attrs) {
-    super(context, attrs);
-  }
+    public FingerprintDialogLayout(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
 
-  public FingerprintDialogLayout(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
-    super(context, attrs, defStyleAttr);
-  }
+    public FingerprintDialogLayout(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
 
-  @Override
-  protected void onFinishInflate() {
-    super.onFinishInflate();
-    iconView = findViewById(R.id.fingerprint_icon);
-    statusView = findViewById(R.id.status);
-  }
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        iconView = findViewById(R.id.fingerprint_icon);
+        statusView = findViewById(R.id.status);
+    }
 
-  @Override
-  protected void onConfigurationChanged(Configuration newConfig) {
-    super.onConfigurationChanged(newConfig);
-    int newMargin = getResources().getDimensionPixelSize(R.dimen.fingerprint_status_layout_margin_vertical);
-    ((MarginLayoutParams) iconView.getLayoutParams()).topMargin = newMargin;
-    ((MarginLayoutParams) statusView.getLayoutParams()).bottomMargin = newMargin;
-  }
+    @Override
+    protected void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        int newMargin = getResources().getDimensionPixelSize(R.dimen.fingerprint_status_layout_margin_vertical);
+        ((MarginLayoutParams) iconView.getLayoutParams()).topMargin = newMargin;
+        ((MarginLayoutParams) statusView.getLayoutParams()).bottomMargin = newMargin;
+    }
 }

--- a/library/src/main/java/moe/feng/support/biometricprompt/FingerprintDialogLayout.java
+++ b/library/src/main/java/moe/feng/support/biometricprompt/FingerprintDialogLayout.java
@@ -1,0 +1,43 @@
+package moe.feng.support.biometricprompt;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
+import android.util.AttributeSet;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+@RestrictTo({ RestrictTo.Scope.LIBRARY })
+public class FingerprintDialogLayout extends LinearLayout {
+
+  private FingerprintIconView iconView;
+  private TextView statusView;
+
+  public FingerprintDialogLayout(Context context) {
+    super(context);
+  }
+
+  public FingerprintDialogLayout(Context context, @Nullable AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public FingerprintDialogLayout(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+  }
+
+  @Override
+  protected void onFinishInflate() {
+    super.onFinishInflate();
+    iconView = findViewById(R.id.fingerprint_icon);
+    statusView = findViewById(R.id.status);
+  }
+
+  @Override
+  protected void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    int newMargin = getResources().getDimensionPixelSize(R.dimen.fingerprint_status_layout_margin_vertical);
+    ((MarginLayoutParams) iconView.getLayoutParams()).topMargin = newMargin;
+    ((MarginLayoutParams) statusView.getLayoutParams()).bottomMargin = newMargin;
+  }
+}

--- a/library/src/main/res/layout/biometric_prompt_dialog_content.xml
+++ b/library/src/main/res/layout/biometric_prompt_dialog_content.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<moe.feng.support.biometricprompt.FingerprintDialogLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/subtitle"
@@ -23,37 +24,31 @@
         android:textAppearance="@android:style/TextAppearance.Material.Subhead"
         tools:text="Description: blabla."/>
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <moe.feng.support.biometricprompt.FingerprintIconView
+        android:id="@+id/fingerprint_icon"
+        android:layout_width="@dimen/fingerprint_icon_size"
+        android:layout_height="@dimen/fingerprint_icon_size"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/fingerprint_status_layout_margin_vertical"/>
+
+    <TextView
+        android:id="@+id/status"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingTop="@dimen/fingerprint_status_layout_margin_vertical"
-        android:paddingBottom="@dimen/fingerprint_status_layout_margin_vertical"
-        android:gravity="center">
-
-        <moe.feng.support.biometricprompt.FingerprintIconView
-            android:id="@+id/fingerprint_icon"
-            android:layout_width="@dimen/fingerprint_icon_size"
-            android:layout_height="@dimen/fingerprint_icon_size" />
-
-        <TextView
-            android:id="@+id/status"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:textAppearance="@android:style/TextAppearance.Material.Small"
-            android:text="@string/touch_fingerprint_sensor_hint"/>
-
-    </LinearLayout>
+        android:layout_marginTop="16dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="@dimen/fingerprint_status_layout_margin_vertical"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:text="@string/touch_fingerprint_sensor_hint"/>
 
     <Button
+        style="@android:style/Widget.Material.Button.Borderless.Small"
         android:id="@android:id/button1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
         android:layout_marginBottom="8dp"
-        style="@android:style/Widget.Material.Button.Borderless.Small"
         android:textColor="?android:colorAccent"
         tools:text="Negative"/>
 
-</LinearLayout>
+</moe.feng.support.biometricprompt.FingerprintDialogLayout>

--- a/library/src/main/res/values-land/dimens.xml
+++ b/library/src/main/res/values-land/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="fingerprint_status_layout_margin_vertical">16dp</dimen>
+</resources>


### PR DESCRIPTION
Resolved #12

BTW, this PR added `android:configChanges="orientation|screenSize"` to the demo activity and handle `onConfigurationChanged` in `FingerprintDialogLayout`, which will resolve the screen rotation causing the dialog rebuild issue (#1).